### PR TITLE
WM_COMMAND added

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -99,6 +99,11 @@ LRESULT CALLBACK BorderlessWindow::WndProc( HWND hWnd, UINT message, WPARAM wPar
         return DefWindowProc( hWnd, message, wParam, lParam );
       }
     }
+    
+    case WM_COMMAND: {
+        SendMessage(hWnd,WM_SYSCOMMAND,wParam,lParam);
+        return DefWindowProc( hWnd, message, wParam, lParam );
+  } break;
 
     case WM_SETFOCUS: {
       QString str( "Got focus" );


### PR DESCRIPTION
[`WM_COMMAND`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms647591%28v=vs.85%29.aspx) : Sent when the user selects a command item from a menu, when a control sends a notification message to its parent window, or when an accelerator keystroke is translated.
